### PR TITLE
Add Buildx for multi-architecture builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Build varnish {{ matrix.version }}
         run: >
-          docker build --pull
+          docker buildx build --pull
           -t ${{ env.GHCR_IMAGE }}:${{ matrix.tag }}
           -t ${{ env.DOCKERHUB_IMAGE }}:${{ matrix.tag }}
+          --platform linux/amd64,linux/arm64,linux/arm64/v8
           ${{ matrix.version }}
 
       - name: Login to github docker registry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,6 @@
 name: build
 
-on:
-  push:
-    branches:
-      - master
-    paths:
-      - .github/workflows/build.yml
+on: push
 
 env:
   GHCR_IMAGE: ghcr.io/emgag/varnish


### PR DESCRIPTION
Based on https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
and https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/

Fixes https://github.com/emgag/docker-varnish/issues/20

You can see the build results on my fork at https://github.com/danielcompton/docker-varnish/runs/3285456234. It looks like the build was successful, but the publish failed (as expected).